### PR TITLE
reorder uses annotations as Buildings 7.0.0 requests Modelica 3.2.3 

### DIFF
--- a/TransiEnt 2.0.2-dev/package.mo
+++ b/TransiEnt 2.0.2-dev/package.mo
@@ -243,13 +243,13 @@ annotation (uses(
     Modelica_StateGraph2(version="2.0.4"),
     DataFiles(version="1.0.5"),
     Design(version="1.0.7"),
-    Buildings(version="7.0.0"),
     Modelica(version="4.0.0"),
     Modelica_LinearSystems2(version="2.4.0"),
     ModelicaReference(version="4.0.0"),
     TILMedia(version="1.8.0 ClaRa"),
     ClaRa(version="1.8.0"),
-    DymolaCommands(version="1.11")),           Icon(coordinateSystem(
+    DymolaCommands(version="1.11"),
+    Buildings(version="7.0.0")),           Icon(coordinateSystem(
           preserveAspectRatio=false, extent={{-100,-100},{100,100}}), graphics={Bitmap(extent={{-70,-62},{72,80}}, fileName="modelica://TransiEnt/Images/TransiEnt_Logo_Kreis_komprimiert.png")}),
   Documentation(info="<html>
 <p><img src=\"modelica://TransiEnt/Images/TransiEntLibraryInfo.png\"/></p>


### PR DESCRIPTION
Buildings 7.0.0 has uses Modelica version 3.2.3 but TransiEnt needs Modelica 4.0.0. 
Reordering the uses annotation should force the loading of MSL 4.0.0 first in OpenModelica.