### PR TITLE
fix update package.order with the new adapter Real_ph_to_Ideal_pT.mo

### DIFF
--- a/TransiEnt 2.0.2-dev/Basics/Adapters/Gas/package.order
+++ b/TransiEnt 2.0.2-dev/Basics/Adapters/Gas/package.order
@@ -1,5 +1,6 @@
 Ideal_to_Real
 Real_to_Ideal
+Real_ph_to_Ideal_pT
 RealH2_to_RealNG
 RealH2O_to_RealNG7_SG
 RealNG7_SG_to_RealSG6


### PR DESCRIPTION
Added the adapter `Real_ph_to_Ideal_pT` to `package.order` so that this adapter could be showed and listed in the library.

```
Ideal_to_Real
Real_to_Ideal
Real_ph_to_Ideal_pT // newly added
RealH2_to_RealNG
RealH2O_to_RealNG7_SG
RealNG7_SG_to_RealSG6
RealNG7_to_RealNG7_SG
RealNG7_to_RealNG7_SG_O2
RealSG6_to_RealNG7_SG
RealSG6_to_RealNG7_SG_O2
RealH2_to_RealSG4
RealSG4_to_RealNG7
RealNG7_to_RealSG4
```
After updating `package.order` you can see the adapter `Real_ph_to_Ideal_pT`:

![TransiEnt](https://github.com/TransiEnt-official/transient-lib/assets/52628547/5fa3d3f3-72e4-4c4d-aa5f-35c6f4b8eda9)

